### PR TITLE
Timestamps

### DIFF
--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -23,7 +23,7 @@ const Progress : FC<ProgressProps> = ({
         <Grid item sx={{ flexGrow: 1 }} display='flex' flexDirection='row' alignItems='center'>
           <LinearProgress
             variant={
-              numCompleted > 0 ? 'determinate' : isProcessing ? 'indeterminate' : 'buffer'
+              numCompleted > 0 ? 'determinate' : isProcessing ? 'indeterminate' : 'determinate'
             }
             value={totalToComplete === 0 ? 0 : (numCompleted / totalToComplete) * 100}
             sx={{ flexGrow: 1 }}

--- a/src/components/SpliceVideo/SplicePoints.tsx
+++ b/src/components/SpliceVideo/SplicePoints.tsx
@@ -1,12 +1,12 @@
 import { FC, useMemo } from 'react'
-import { Box, Button, IconButton, Input, Stack, Typography } from '@mui/material'
+import { Box, Button, IconButton, Input, InputLabel, Stack, Typography } from '@mui/material'
 import useSpliceVideo from '@/hooks/useSpliceVideo'
 import { Add, Delete } from '@mui/icons-material'
 
-const SplicePoints: FC = () => {
-  const { selectedVideo, splicePoints, addSplicePoint, deleteSplicePoint, modifySplicePoint } = useSpliceVideo()
+const SplicePoints: FC= () => {
+  const { selectedVideo, splicePoints, addSplicePoint, deleteSplicePoint, modifySplicePoint, videoRef } = useSpliceVideo()
 
-  const video = document.getElementById('splice-video') as HTMLVideoElement
+  const video = videoRef?.current
 
   const handleAddSplicePoint = () => {
     if (!video) {
@@ -59,12 +59,16 @@ const SplicePoints: FC = () => {
   }
 
   const videoDuration = useMemo(() => {
-    if (!video) {
-      return 0
-    }
+    return video?.duration || 0
+  }, [video?.duration])
 
-    return video.duration
-  }, [selectedVideo])
+  const convertSecondsToHoursMinutesSeconds = (seconds: number) => {
+    const hours = Math.floor(seconds / 3600)
+    const minutes = Math.floor((seconds - hours * 3600) / 60)
+    const secondsLeft = seconds - hours * 3600 - minutes * 60
+
+    return [hours, minutes, secondsLeft]
+  }
 
   return (
     <>
@@ -85,78 +89,237 @@ const SplicePoints: FC = () => {
         }}
       >
         {
-          splicePoints && splicePoints.map(([start, end], i) => (
-            <Stack key={i} direction='row' justifyContent='space-between' alignItems='center' mb={2} ml={{
-              xs: 0,
-              md: 1.5,
-            }}>
-              <Stack direction='row' alignItems='center' spacing={2}>
-                <Stack alignItems='center'>
-                  <Input
-                    type='number'
-                    value={start}
-                    componentsProps={{
-                      input: {
-                        min: 0,
-                        max: end,
-                      }
-                    }}
-                    fullWidth
-                    onChange={(e) => {
-                      const newStart = Number(e.target.value)
+          splicePoints && splicePoints.map(([start, end], i) => {
+            const [startHours, startMinutes, startSeconds] = convertSecondsToHoursMinutesSeconds(start)
+            const [endHours, endMinutes, endSeconds] = convertSecondsToHoursMinutesSeconds(end)
 
-                      if (!video || newStart > end || newStart < 0) {
-                        return
-                      }
+            return (
+              <Stack key={i} gap={2} direction='row' justifyContent='space-between' alignItems='center' mb={2} ml={{
+                xs: 0,
+                md: 1.5,
+              }}>
+                <Stack direction='row' alignItems='center' spacing={2} width='100%'>
+                  <Stack alignItems='center' width='100%'>
+                    <Stack direction='row' spacing={2} width='100%'>
+                      <Box width='100%'>
+                        <InputLabel>Hours</InputLabel>
+                        <Input
+                          type='number'
+                          value={startHours}
+                          componentsProps={{
+                            input: {
+                              min: 0,
+                              max: endHours,
+                            }
+                          }}
+                          fullWidth
+                          onChange={(e) => {
+                            const newStartHours = Number(e.target.value)
 
-                      video.currentTime = newStart
+                            if (!video || newStartHours > endHours || newStartHours < 0) {
+                              return
+                            }
 
-                      modifySplicePoint([start, end], [newStart, end])
-                    }}
-                  />
-                  <Button onClick={() => handleSetStartPoint([start, end])}>
-                    Set Current
-                  </Button>
-                  <Button onClick={() => handleGoToSplicePoint(start)}>
-                    Go to Time
-                  </Button>
+                            video.currentTime = newStartHours * 3600 + startMinutes * 60 + startSeconds
+
+                            modifySplicePoint([start, end], [newStartHours * 3600 + startMinutes * 60 + startSeconds, end])
+                          }}
+                        />
+                      </Box>
+                      <Box width='100%'>
+                        <InputLabel>Minutes</InputLabel>
+                        <Input
+                          type='number'
+                          value={startMinutes}
+                          componentsProps={{
+                            input: {
+                              min: 0,
+                              max: endMinutes,
+                            }
+                          }}
+                          fullWidth
+                          onChange={(e) => {
+                            const newStartMinutes = Number(e.target.value)
+
+                            if (!video || newStartMinutes > endMinutes || newStartMinutes < 0) {
+                              return
+                            }
+
+                            video.currentTime = startHours * 3600 + newStartMinutes * 60 + startSeconds
+
+                            modifySplicePoint([start, end], [startHours * 3600 + newStartMinutes * 60 + startSeconds, end])
+                          }}
+                        />
+                      </Box>
+                      <Box width='100%'>
+                        <InputLabel>Seconds</InputLabel>
+                        <Input
+                          type='number'
+                          value={startSeconds}
+                          componentsProps={{
+                            input: {
+                              min: 0,
+                              max: endSeconds,
+                            }
+                          }}
+                          fullWidth
+                          onChange={(e) => {
+                            const newStartSeconds = Number(e.target.value)
+
+                            if (!video || newStartSeconds > endSeconds || newStartSeconds < 0) {
+                              return
+                            }
+
+                            video.currentTime = startHours * 3600 + startMinutes * 60 + newStartSeconds
+
+                            modifySplicePoint([start, end], [startHours * 3600 + startMinutes * 60 + newStartSeconds, end])
+                          }}
+                        />
+                      </Box>
+                    </Stack>
+                    <Input
+                      type='number'
+                      value={start}
+                      componentsProps={{
+                        input: {
+                          min: 0,
+                          max: end,
+                        }
+                      }}
+                      fullWidth
+                      onChange={(e) => {
+                        const newStart = Number(e.target.value)
+
+                        if (!video || newStart > end || newStart < 0) {
+                          return
+                        }
+
+                        video.currentTime = newStart
+
+                        modifySplicePoint([start, end], [newStart, end])
+                      }}
+                    />
+                    <Button onClick={() => handleSetStartPoint([start, end])}>
+                      Set Current
+                    </Button>
+                    <Button onClick={() => handleGoToSplicePoint(start)}>
+                      Go to Time
+                    </Button>
+                  </Stack>
+                  <Stack alignItems='center' width='100%'>
+                    <Stack direction='row' spacing={2} width='100%'>
+                      <Box width='100%'>
+                        <InputLabel>Hours</InputLabel>
+                        <Input
+                          type='number'
+                          value={endHours}
+                          componentsProps={{
+                            input: {
+                              min: startHours,
+                              max: Math.floor(videoDuration / 3600),
+                            }
+                          }}
+                          fullWidth
+                          onChange={(e) => {
+                            const newEndHours = Number(e.target.value)
+
+                            if (!video || newEndHours < startHours || newEndHours > Math.floor(videoDuration / 3600)) {
+                              return
+                            }
+
+                            video.currentTime = newEndHours * 3600 + endMinutes * 60 + endSeconds
+
+                            modifySplicePoint([start, end], [start, newEndHours * 3600 + endMinutes * 60 + endSeconds])
+                          }}
+                        />
+                      </Box>
+                      <Box width='100%'>
+                        <InputLabel>Minutes</InputLabel>
+                        <Input
+                          type='number'
+                          value={endMinutes}
+                          componentsProps={{
+                            input: {
+                              min: startMinutes,
+                              max: 59,
+                            }
+                          }}
+                          fullWidth
+                          onChange={(e) => {
+                            const newEndMinutes = Number(e.target.value)
+
+                            if (!video || newEndMinutes < startMinutes || newEndMinutes > 59) {
+                              return
+                            }
+
+                            video.currentTime = endHours * 3600 + newEndMinutes * 60 + endSeconds
+
+                            modifySplicePoint([start, end], [start, endHours * 3600 + newEndMinutes * 60 + endSeconds])
+                          }}
+                        />
+                      </Box>
+                      <Box width='100%'>
+                        <InputLabel>Seconds</InputLabel>
+                        <Input
+                          type='number'
+                          value={endSeconds}
+                          componentsProps={{
+                            input: {
+                              min: startSeconds,
+                              max: 59,
+                            }
+                          }}
+                          fullWidth
+                          onChange={(e) => {
+                            const newEndSeconds = Number(e.target.value)
+
+                            if (!video || newEndSeconds < startSeconds || newEndSeconds > 59) {
+                              return
+                            }
+
+                            video.currentTime = endHours * 3600 + endMinutes * 60 + newEndSeconds
+
+                            modifySplicePoint([start, end], [start, endHours * 3600 + endMinutes * 60 + newEndSeconds])
+                          }}
+                        />
+                      </Box>
+                    </Stack>
+                    <Input
+                      type='number'
+                      value={end}
+                      componentsProps={{
+                        input: {
+                          min: start,
+                          max: videoDuration,
+                        }
+                      }}
+                      fullWidth
+                      onChange={(e) => {
+                        const newEnd = Number(e.target.value)
+
+                        if (!video || newEnd > videoDuration || newEnd < start) {
+                          return
+                        }
+
+                        video.currentTime = newEnd
+
+                        modifySplicePoint([start, end], [start, newEnd])
+                      }}
+                    />
+                    <Button onClick={() => handleSetEndPoint([start, end])}>
+                      Set Current
+                    </Button>
+                    <Button onClick={() => handleGoToSplicePoint(end)}>
+                      Go to Time
+                    </Button>
+                  </Stack>
                 </Stack>
-                <Stack alignItems='center'>
-                  <Input
-                    type='number'
-                    value={end}
-                    componentsProps={{
-                      input: {
-                        min: start,
-                        max: videoDuration,
-                      }
-                    }}
-                    fullWidth
-                    onChange={(e) => {
-                      const newEnd = Number(e.target.value)
-
-                      if (!video || newEnd > videoDuration || newEnd < start) {
-                        return
-                      }
-
-                      video.currentTime = newEnd
-
-                      modifySplicePoint([start, end], [start, newEnd])
-                    }}
-                  />
-                  <Button onClick={() => handleSetEndPoint([start, end])}>
-                    Set Current
-                  </Button>
-                  <Button onClick={() => handleGoToSplicePoint(end)}>
-                    Go to Time
-                  </Button>
-                </Stack>
+                <IconButton color='error' onClick={() => deleteSplicePoint([start, end])}>
+                  <Delete />
+                </IconButton>
               </Stack>
-              <IconButton color='error' onClick={() => deleteSplicePoint([start, end])}>
-                <Delete />
-              </IconButton>
-            </Stack>
-          ))
+            )
+          })
         }
       </Box>
     </>

--- a/src/components/SpliceVideo/SplicePoints.tsx
+++ b/src/components/SpliceVideo/SplicePoints.tsx
@@ -162,8 +162,8 @@ const SplicePoints: FC = () => {
                           value={startMinutes}
                           componentsProps={{
                             input: {
-                              min: 0,
-                              max: 59,
+                              min: -1,
+                              max: 60,
                             }
                           }}
                           fullWidth
@@ -298,8 +298,8 @@ const SplicePoints: FC = () => {
                           value={endMinutes}
                           componentsProps={{
                             input: {
-                              min: 0,
-                              max: 59,
+                              min: -1,
+                              max: 60,
                             }
                           }}
                           fullWidth
@@ -326,8 +326,8 @@ const SplicePoints: FC = () => {
                           value={endSeconds}
                           componentsProps={{
                             input: {
-                              min: 0,
-                              max: 59,
+                              min: -1,
+                              max: 60,
                             }
                           }}
                           fullWidth

--- a/src/components/SpliceVideo/SplicePoints.tsx
+++ b/src/components/SpliceVideo/SplicePoints.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo } from 'react'
-import { Box, Button, IconButton, Input, InputLabel, Stack } from '@mui/material'
+import { Box, Button, IconButton, Input, InputLabel, Stack, Typography } from '@mui/material'
 import useSpliceVideo from '@/hooks/useSpliceVideo'
 import { Add, Delete } from '@mui/icons-material'
 
@@ -124,7 +124,7 @@ const SplicePoints: FC = () => {
                 md: 1.5,
               }}>
                 <Stack direction='row' alignItems='center' spacing={2} width='100%'>
-                  <Stack alignItems='center' width='100%'>
+                  <Stack alignItems='center' width='100%' spacing={1}>
                     <Stack direction='row' spacing={2} width='100%'>
                       <Box width='100%'>
                         <InputLabel>Hours</InputLabel>
@@ -214,7 +214,12 @@ const SplicePoints: FC = () => {
                         />
                       </Box>
                     </Stack>
-                    <Box width='100%' mt={1}>
+                    <Box>
+                      <Typography variant='caption'>
+                        OR
+                      </Typography>
+                    </Box>
+                    <Box width='100%'>
                       <InputLabel>Frame</InputLabel>
                       <Input
                         type='number'
@@ -247,14 +252,16 @@ const SplicePoints: FC = () => {
                         }}
                       />
                     </Box>
-                    <Button onClick={() => handleSetStartPoint([start, end])}>
-                      Set Current
-                    </Button>
-                    <Button onClick={() => handleGoToSplicePoint(start)}>
-                      Go to Time
-                    </Button>
+                    <Stack>
+                      <Button onClick={() => handleSetStartPoint([start, end])}>
+                        Set to Current Time
+                      </Button>
+                      <Button onClick={() => handleGoToSplicePoint(start)}>
+                        Go to Time
+                      </Button>
+                    </Stack>
                   </Stack>
-                  <Stack alignItems='center' width='100%'>
+                  <Stack alignItems='center' width='100%' spacing={1}>
                     <Stack direction='row' spacing={2} width='100%'>
                       <Box width='100%'>
                         <InputLabel>Hours</InputLabel>
@@ -342,7 +349,12 @@ const SplicePoints: FC = () => {
                         />
                       </Box>
                     </Stack>
-                    <Box width='100%' mt={1}>
+                    <Box>
+                      <Typography variant='caption'>
+                        OR
+                      </Typography>
+                    </Box>
+                    <Box width='100%'>
                       <InputLabel>Frame</InputLabel>
                       <Input
                         type='number'
@@ -375,12 +387,14 @@ const SplicePoints: FC = () => {
                         }}
                       />
                     </Box>
-                    <Button onClick={() => handleSetEndPoint([start, end])}>
-                      Set Current
-                    </Button>
-                    <Button onClick={() => handleGoToSplicePoint(end)}>
-                      Go to Time
-                    </Button>
+                    <Stack>
+                      <Button onClick={() => handleSetEndPoint([start, end])}>
+                        Set to Current Time
+                      </Button>
+                      <Button onClick={() => handleGoToSplicePoint(end)}>
+                        Go to Time
+                      </Button>
+                    </Stack>
                   </Stack>
                 </Stack>
                 <IconButton color='error' onClick={() => deleteSplicePoint([start, end])}>

--- a/src/components/SpliceVideo/SplicePoints.tsx
+++ b/src/components/SpliceVideo/SplicePoints.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useEffect } from 'react'
+import { FC, useMemo } from 'react'
 import { Box, Button, IconButton, Input, InputLabel, Stack } from '@mui/material'
 import useSpliceVideo from '@/hooks/useSpliceVideo'
 import { Add, Delete } from '@mui/icons-material'
@@ -6,33 +6,31 @@ import { Add, Delete } from '@mui/icons-material'
 const SplicePoints: FC = () => {
   const { selectedVideo, splicePoints, addSplicePoint, deleteSplicePoint, modifySplicePoint, videoRef, videoFramerate } = useSpliceVideo()
 
-  const video = videoRef?.current
-
   const handleAddSplicePoint = () => {
-    if (!video) {
+    if (!videoRef) {
       return
     }
 
-    addSplicePoint(video.currentTime)
+    addSplicePoint(videoRef.currentTime)
   }
 
   const handleGoToSplicePoint = (splicePoint: number) => {
-    if (!video) {
+    if (!videoRef) {
       return
     }
 
-    video.currentTime = splicePoint
+    videoRef.currentTime = splicePoint
   }
 
   // handle setting startpoint; make sure it's not after the end point
   const handleSetStartPoint = (splicePoint: [number, number]) => {
     const [_, endPoint] = splicePoint
 
-    if (!video) {
+    if (!videoRef) {
       return
     }
 
-    const newStartPoint = video.currentTime
+    const newStartPoint = videoRef.currentTime
 
     if (newStartPoint > endPoint) {
       return
@@ -45,11 +43,11 @@ const SplicePoints: FC = () => {
   const handleSetEndPoint = (splicePoint: [number, number]) => {
     const [startPoint, _] = splicePoint
 
-    if (!video) {
+    if (!videoRef) {
       return
     }
 
-    const newEndPoint = video.currentTime
+    const newEndPoint = videoRef.currentTime
 
     if (newEndPoint < startPoint) {
       return
@@ -59,8 +57,8 @@ const SplicePoints: FC = () => {
   }
 
   const videoDuration = useMemo(() => {
-    return video?.duration || 0
-  }, [video?.duration])
+    return videoRef?.duration || 0
+  }, [videoRef?.duration])
 
   const convertSecondsToHoursMinutesSeconds = (seconds: number) => {
     const hours = Math.floor(seconds / 3600)
@@ -131,11 +129,11 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newStartHours = Number(e.target.value)
 
-                            if (!video || newStartHours > endHours || newStartHours < 0) {
+                            if (!videoRef || newStartHours > endHours || newStartHours < 0) {
                               return
                             }
 
-                            video.currentTime = newStartHours * 3600 + startMinutes * 60 + startSeconds
+                            videoRef.currentTime = newStartHours * 3600 + startMinutes * 60 + startSeconds
 
                             modifySplicePoint([start, end], [newStartHours * 3600 + startMinutes * 60 + startSeconds, end])
                           }}
@@ -156,11 +154,11 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newStartMinutes = Number(e.target.value)
 
-                            if (!video || newStartMinutes > endMinutes || newStartMinutes < 0) {
+                            if (!videoRef || newStartMinutes > endMinutes || newStartMinutes < 0) {
                               return
                             }
 
-                            video.currentTime = startHours * 3600 + newStartMinutes * 60 + startSeconds
+                            videoRef.currentTime = startHours * 3600 + newStartMinutes * 60 + startSeconds
 
                             modifySplicePoint([start, end], [startHours * 3600 + newStartMinutes * 60 + startSeconds, end])
                           }}
@@ -181,11 +179,11 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newStartSeconds = Number(e.target.value)
 
-                            if (!video || newStartSeconds > endSeconds || newStartSeconds < 0) {
+                            if (!videoRef || newStartSeconds > endSeconds || newStartSeconds < 0) {
                               return
                             }
 
-                            video.currentTime = startHours * 3600 + startMinutes * 60 + newStartSeconds
+                            videoRef.currentTime = startHours * 3600 + startMinutes * 60 + newStartSeconds
 
                             modifySplicePoint([start, end], [startHours * 3600 + startMinutes * 60 + newStartSeconds, end])
                           }}
@@ -208,7 +206,7 @@ const SplicePoints: FC = () => {
                           const newStartFrames = Number(e.target.value)
                           let newSeconds = convertFramesToSeconds(newStartFrames)
 
-                          if (!video || newStartFrames > endFrames || newStartFrames < 0) {
+                          if (!videoRef || newStartFrames > endFrames || newStartFrames < 0) {
                             return
                           }
 
@@ -219,7 +217,7 @@ const SplicePoints: FC = () => {
                             newSeconds += 0.0001
                           }
 
-                          video.currentTime = newSeconds
+                          videoRef.currentTime = newSeconds
 
                           modifySplicePoint([start, end], [newSeconds, end])
                         }}
@@ -249,11 +247,11 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newEndHours = Number(e.target.value)
 
-                            if (!video || newEndHours < startHours || newEndHours > Math.floor(videoDuration / 3600)) {
+                            if (!videoRef || newEndHours < startHours || newEndHours > Math.floor(videoDuration / 3600)) {
                               return
                             }
 
-                            video.currentTime = newEndHours * 3600 + endMinutes * 60 + endSeconds
+                            videoRef.currentTime = newEndHours * 3600 + endMinutes * 60 + endSeconds
 
                             modifySplicePoint([start, end], [start, newEndHours * 3600 + endMinutes * 60 + endSeconds])
                           }}
@@ -299,11 +297,11 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newEndSeconds = Number(e.target.value)
 
-                            if (!video || newEndSeconds < startSeconds || newEndSeconds > 59) {
+                            if (!videoRef || newEndSeconds < startSeconds || newEndSeconds > 59) {
                               return
                             }
 
-                            video.currentTime = endHours * 3600 + endMinutes * 60 + newEndSeconds
+                            videoRef.currentTime = endHours * 3600 + endMinutes * 60 + newEndSeconds
 
                             modifySplicePoint([start, end], [start, endHours * 3600 + endMinutes * 60 + newEndSeconds])
                           }}
@@ -326,7 +324,7 @@ const SplicePoints: FC = () => {
                           const newEndFrames = Number(e.target.value)
                           let newSeconds = convertFramesToSeconds(newEndFrames)
 
-                          if (!video || newEndFrames < startFrames || newEndFrames > videoTotalFrames) {
+                          if (!videoRef || newEndFrames < startFrames || newEndFrames > videoTotalFrames) {
                             return
                           }
 
@@ -337,7 +335,7 @@ const SplicePoints: FC = () => {
                             newSeconds += 0.0001
                           }
 
-                          video.currentTime = newSeconds
+                          videoRef.currentTime = newSeconds
 
                           modifySplicePoint([start, end], [start, newSeconds])
                         }}

--- a/src/components/SpliceVideo/SplicePoints.tsx
+++ b/src/components/SpliceVideo/SplicePoints.tsx
@@ -68,6 +68,10 @@ const SplicePoints: FC = () => {
     return [hours, minutes, secondsLeft]
   }
 
+  const convertHoursMinutesSecondsToSeconds = (hours: number, minutes: number, seconds: number) => {
+    return hours * 3600 + minutes * 60 + seconds
+  }
+
   const convertSecondsToFrames = (seconds: number) => {
     return Math.floor(seconds * videoFramerate!)
   }
@@ -122,20 +126,23 @@ const SplicePoints: FC = () => {
                           componentsProps={{
                             input: {
                               min: 0,
-                              max: endHours,
+                              max: Math.floor(videoDuration / 3600),
                             }
                           }}
                           fullWidth
                           onChange={(e) => {
                             const newStartHours = Number(e.target.value)
 
-                            if (!videoRef || newStartHours > endHours || newStartHours < 0) {
+                            const newTimestamp = convertHoursMinutesSecondsToSeconds(newStartHours, startMinutes, startSeconds)
+
+                            // check if newStartHours would make startFrames > endFrames
+                            if (!videoRef || convertSecondsToFrames(newTimestamp) > endFrames) {
                               return
                             }
 
-                            videoRef.currentTime = newStartHours * 3600 + startMinutes * 60 + startSeconds
+                            videoRef.currentTime = newTimestamp
 
-                            modifySplicePoint([start, end], [newStartHours * 3600 + startMinutes * 60 + startSeconds, end])
+                            modifySplicePoint([start, end], [newTimestamp, end])
                           }}
                         />
                       </Box>
@@ -147,20 +154,23 @@ const SplicePoints: FC = () => {
                           componentsProps={{
                             input: {
                               min: 0,
-                              max: endMinutes,
+                              max: 59,
                             }
                           }}
                           fullWidth
                           onChange={(e) => {
                             const newStartMinutes = Number(e.target.value)
 
-                            if (!videoRef || newStartMinutes > endMinutes || newStartMinutes < 0) {
+                            const newTimestamp = convertHoursMinutesSecondsToSeconds(startHours, newStartMinutes, startSeconds)
+
+                            // check if newStartMinutes would make startFrames > endFrames
+                            if (!videoRef || convertSecondsToFrames(newTimestamp) > endFrames) {
                               return
                             }
 
-                            videoRef.currentTime = startHours * 3600 + newStartMinutes * 60 + startSeconds
+                            videoRef.currentTime = newTimestamp
 
-                            modifySplicePoint([start, end], [startHours * 3600 + newStartMinutes * 60 + startSeconds, end])
+                            modifySplicePoint([start, end], [newTimestamp, end])
                           }}
                         />
                       </Box>
@@ -172,20 +182,24 @@ const SplicePoints: FC = () => {
                           componentsProps={{
                             input: {
                               min: 0,
-                              max: endSeconds,
+                              max: 59,
                             }
                           }}
                           fullWidth
                           onChange={(e) => {
                             const newStartSeconds = Number(e.target.value)
 
-                            if (!videoRef || newStartSeconds > endSeconds || newStartSeconds < 0) {
+                            const newTimestamp = convertHoursMinutesSecondsToSeconds(startHours, startMinutes, newStartSeconds)
+
+                            // check if newStartSeconds would make startFrames > endFrames
+                            // if so, return
+                            if (!videoRef || convertSecondsToFrames(newTimestamp) > endFrames) {
                               return
                             }
 
-                            videoRef.currentTime = startHours * 3600 + startMinutes * 60 + newStartSeconds
+                            videoRef.currentTime = newTimestamp
 
-                            modifySplicePoint([start, end], [startHours * 3600 + startMinutes * 60 + newStartSeconds, end])
+                            modifySplicePoint([start, end], [newTimestamp, end])
                           }}
                         />
                       </Box>
@@ -206,7 +220,7 @@ const SplicePoints: FC = () => {
                           const newStartFrames = Number(e.target.value)
                           let newSeconds = convertFramesToSeconds(newStartFrames)
 
-                          if (!videoRef || newStartFrames > endFrames || newStartFrames < 0) {
+                          if (!videoRef || newStartFrames > endFrames) {
                             return
                           }
 
@@ -247,13 +261,16 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newEndHours = Number(e.target.value)
 
-                            if (!videoRef || newEndHours < startHours || newEndHours > Math.floor(videoDuration / 3600)) {
+                            const newTimestamp = convertHoursMinutesSecondsToSeconds(newEndHours, endMinutes, endSeconds)
+
+                            // check if newEndHours would make startFrames > endFrames
+                            if (!videoRef || convertSecondsToFrames(newTimestamp) < startFrames) {
                               return
                             }
 
-                            videoRef.currentTime = newEndHours * 3600 + endMinutes * 60 + endSeconds
+                            videoRef.currentTime = newTimestamp
 
-                            modifySplicePoint([start, end], [start, newEndHours * 3600 + endMinutes * 60 + endSeconds])
+                            modifySplicePoint([start, end], [start, newTimestamp])
                           }}
                         />
                       </Box>
@@ -264,7 +281,7 @@ const SplicePoints: FC = () => {
                           value={endMinutes}
                           componentsProps={{
                             input: {
-                              min: startMinutes,
+                              min: 0,
                               max: 59,
                             }
                           }}
@@ -272,13 +289,16 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newEndMinutes = Number(e.target.value)
 
-                            if (!video || newEndMinutes < startMinutes || newEndMinutes > 59) {
+                            const newTimestamp = convertHoursMinutesSecondsToSeconds(endHours, newEndMinutes, endSeconds)
+
+                            // check if newEndMinutes would make startFrames > endFrames
+                            if (!videoRef || convertSecondsToFrames(newTimestamp) < startFrames) {
                               return
                             }
 
-                            video.currentTime = endHours * 3600 + newEndMinutes * 60 + endSeconds
+                            videoRef.currentTime = newTimestamp
 
-                            modifySplicePoint([start, end], [start, endHours * 3600 + newEndMinutes * 60 + endSeconds])
+                            modifySplicePoint([start, end], [start, newTimestamp])
                           }}
                         />
                       </Box>
@@ -289,7 +309,7 @@ const SplicePoints: FC = () => {
                           value={endSeconds}
                           componentsProps={{
                             input: {
-                              min: startSeconds,
+                              min: 0,
                               max: 59,
                             }
                           }}
@@ -297,13 +317,17 @@ const SplicePoints: FC = () => {
                           onChange={(e) => {
                             const newEndSeconds = Number(e.target.value)
 
-                            if (!videoRef || newEndSeconds < startSeconds || newEndSeconds > 59) {
+                            const newTimestamp = convertHoursMinutesSecondsToSeconds(endHours, endMinutes, newEndSeconds)
+
+                            // check if newEndSeconds would make startFrames > endFrames
+                            // if so, return
+                            if (!videoRef || convertSecondsToFrames(newTimestamp) < startFrames) {
                               return
                             }
 
-                            videoRef.currentTime = endHours * 3600 + endMinutes * 60 + newEndSeconds
+                            videoRef.currentTime = newTimestamp
 
-                            modifySplicePoint([start, end], [start, endHours * 3600 + endMinutes * 60 + newEndSeconds])
+                            modifySplicePoint([start, end], [start, newTimestamp])
                           }}
                         />
                       </Box>

--- a/src/components/SpliceVideo/SplicePoints.tsx
+++ b/src/components/SpliceVideo/SplicePoints.tsx
@@ -84,6 +84,14 @@ const SplicePoints: FC = () => {
     return convertSecondsToFrames(videoDuration)
   }, [videoDuration])
 
+  const verifyStartSeconds = (startSeconds: number, endSeconds: number) => {
+    return (startSeconds <= endSeconds && startSeconds >= 0 && startSeconds <= videoDuration)
+  }
+
+  const verifyEndSeconds = (startSeconds: number, endSeconds: number) => {
+    return (endSeconds >= startSeconds && endSeconds <= videoDuration && endSeconds >= 0)
+  }
+
   return (
     <>
       <Button
@@ -136,7 +144,8 @@ const SplicePoints: FC = () => {
                             const newTimestamp = convertHoursMinutesSecondsToSeconds(newStartHours, startMinutes, startSeconds)
 
                             // check if newStartHours would make startFrames > endFrames
-                            if (!videoRef || convertSecondsToFrames(newTimestamp) > endFrames) {
+                            // or make the number of seconds a negative number; if so, return
+                            if (!videoRef || !verifyStartSeconds(newTimestamp, end)) {
                               return
                             }
 
@@ -164,7 +173,8 @@ const SplicePoints: FC = () => {
                             const newTimestamp = convertHoursMinutesSecondsToSeconds(startHours, newStartMinutes, startSeconds)
 
                             // check if newStartMinutes would make startFrames > endFrames
-                            if (!videoRef || convertSecondsToFrames(newTimestamp) > endFrames) {
+                            // or make the number of seconds a negative number; if so, return
+                            if (!videoRef || !verifyStartSeconds(newTimestamp, end)) {
                               return
                             }
 
@@ -181,8 +191,8 @@ const SplicePoints: FC = () => {
                           value={startSeconds}
                           componentsProps={{
                             input: {
-                              min: 0,
-                              max: 59,
+                              min: -1,
+                              max: 60,
                             }
                           }}
                           fullWidth
@@ -192,8 +202,8 @@ const SplicePoints: FC = () => {
                             const newTimestamp = convertHoursMinutesSecondsToSeconds(startHours, startMinutes, newStartSeconds)
 
                             // check if newStartSeconds would make startFrames > endFrames
-                            // if so, return
-                            if (!videoRef || convertSecondsToFrames(newTimestamp) > endFrames) {
+                            // or make the number of seconds a negative number; if so, return
+                            if (!videoRef || !verifyStartSeconds(newTimestamp, end)) {
                               return
                             }
 
@@ -264,7 +274,7 @@ const SplicePoints: FC = () => {
                             const newTimestamp = convertHoursMinutesSecondsToSeconds(newEndHours, endMinutes, endSeconds)
 
                             // check if newEndHours would make startFrames > endFrames
-                            if (!videoRef || convertSecondsToFrames(newTimestamp) < startFrames) {
+                            if (!videoRef || !verifyEndSeconds(start, newTimestamp)) {
                               return
                             }
 
@@ -292,7 +302,7 @@ const SplicePoints: FC = () => {
                             const newTimestamp = convertHoursMinutesSecondsToSeconds(endHours, newEndMinutes, endSeconds)
 
                             // check if newEndMinutes would make startFrames > endFrames
-                            if (!videoRef || convertSecondsToFrames(newTimestamp) < startFrames) {
+                            if (!videoRef || !verifyEndSeconds(start, newTimestamp)) {
                               return
                             }
 
@@ -321,7 +331,7 @@ const SplicePoints: FC = () => {
 
                             // check if newEndSeconds would make startFrames > endFrames
                             // if so, return
-                            if (!videoRef || convertSecondsToFrames(newTimestamp) < startFrames) {
+                            if (!videoRef || !verifyEndSeconds(start, newTimestamp)) {
                               return
                             }
 

--- a/src/components/SpliceVideo/VideoControls.tsx
+++ b/src/components/SpliceVideo/VideoControls.tsx
@@ -1,17 +1,15 @@
 import { FC, useEffect, useState } from 'react'
 import useSpliceVideo from '@/hooks/useSpliceVideo'
-import { Alert, Box, IconButton, Snackbar, Stack, Tooltip } from '@mui/material'
+import { Box, IconButton, Stack, Tooltip } from '@mui/material'
 import { FirstPage, LastPage, PlayArrow, SkipNext, SkipPrevious, Pause, Replay, Replay5, Forward5, Replay10, Forward10 } from '@mui/icons-material'
-import { ipcRenderer } from 'electron'
+
 
 const VideoControls: FC = () => {
-  const { selectedVideo, videoFramerate } = useSpliceVideo()
+  const { selectedVideo, videoFramerate, videoRef } = useSpliceVideo()
 
   const video = document.getElementById('splice-video') as HTMLVideoElement
 
   const [videoState, setVideoState] = useState<'playing' | 'paused'>('paused')
-
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     if (!video) {
@@ -75,7 +73,7 @@ const VideoControls: FC = () => {
     <>
       {selectedVideo && (
         <>
-          <video id='splice-video' controls key={selectedVideo} style={{ width: '100%', height: 'auto', maxHeight: '100%' }}>
+          <video id='splice-video' controls key={selectedVideo} style={{ width: '100%', height: 'auto', maxHeight: '100%' }} ref={videoRef}>
             <source src={`media-loader://${selectedVideo}`} />
           </video>
           <Box display='flex' justifyContent='center'>
@@ -162,13 +160,6 @@ const VideoControls: FC = () => {
             </Stack>
           </Box>
         </>
-      )}
-      {!!errorMessage && (
-        <Snackbar open={!!errorMessage} autoHideDuration={6000} onClose={() => setErrorMessage(null)}>
-          <Alert severity='error' onClose={() => setErrorMessage(null)}>
-            {errorMessage}
-          </Alert>
-        </Snackbar>
       )}
     </>
   )

--- a/src/components/SpliceVideo/VideoControls.tsx
+++ b/src/components/SpliceVideo/VideoControls.tsx
@@ -5,7 +5,7 @@ import { FirstPage, LastPage, PlayArrow, SkipNext, SkipPrevious, Pause, Replay, 
 
 
 const VideoControls: FC = () => {
-  const { selectedVideo, videoFramerate, videoRef } = useSpliceVideo()
+  const { selectedVideo, videoFramerate, setVideoRef } = useSpliceVideo()
 
   const video = document.getElementById('splice-video') as HTMLVideoElement
 
@@ -73,7 +73,7 @@ const VideoControls: FC = () => {
     <>
       {selectedVideo && (
         <>
-          <video id='splice-video' controls key={selectedVideo} style={{ width: '100%', height: 'auto', maxHeight: '100%' }} ref={videoRef}>
+          <video id='splice-video' controls key={selectedVideo} style={{ width: '100%', height: 'auto', maxHeight: '100%' }} ref={setVideoRef}>
             <source src={`media-loader://${selectedVideo}`} />
           </video>
           <Box display='flex' justifyContent='center'>

--- a/src/components/SpliceVideo/VideoControls.tsx
+++ b/src/components/SpliceVideo/VideoControls.tsx
@@ -5,42 +5,13 @@ import { FirstPage, LastPage, PlayArrow, SkipNext, SkipPrevious, Pause, Replay, 
 import { ipcRenderer } from 'electron'
 
 const VideoControls: FC = () => {
-  const { selectedVideo } = useSpliceVideo()
+  const { selectedVideo, videoFramerate } = useSpliceVideo()
 
   const video = document.getElementById('splice-video') as HTMLVideoElement
 
   const [videoState, setVideoState] = useState<'playing' | 'paused'>('paused')
-  const [videoFramerate, setVideoFramerate] = useState<number | null>(null)
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
-
-  // when selectedVideo changes, use electron to get the framerate of the video
-  useEffect(() => {
-    if (!selectedVideo) {
-      setVideoFramerate(null)
-      return
-    }
-
-    ipcRenderer.send('get-video-framerate', {
-      videoPath: selectedVideo,
-    })
-
-    ipcRenderer.once('got-video-framerate', (_, framerate) => {
-      // evaluate the string as a number; it is in the form of '30/1'
-      framerate = eval(framerate)
-      setVideoFramerate(framerate)
-    })
-
-    ipcRenderer.once('get-video-framerate-failed', (_, errorMessage) => {
-      setErrorMessage(errorMessage)
-    })
-
-
-    return () => {
-      ipcRenderer.removeAllListeners('got-video-framerate')
-      ipcRenderer.removeAllListeners('get-video-framerate-failed')
-    }
-  }, [selectedVideo])
 
   useEffect(() => {
     if (!video) {

--- a/src/contexts/SpliceVideoContext.tsx
+++ b/src/contexts/SpliceVideoContext.tsx
@@ -1,6 +1,6 @@
 import { ipcRenderer } from 'electron'
 import { FC, createContext, useMemo, useState } from 'react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 export interface SpliceVideoContextValue {
   selectedVideo: string
@@ -18,6 +18,7 @@ export interface SpliceVideoContextValue {
   }) => void
   errorMessages: string[]
   videoFramerate: number | null
+  videoRef?: React.RefObject<HTMLVideoElement>
 }
 
 const SpliceVideoContext = createContext<SpliceVideoContextValue>(undefined as any)
@@ -36,6 +37,8 @@ export const SpliceVideoProvider: FC<SpliceVideoProviderProps> = ({ children }) 
 
   // when selectedVideo changes, use electron to get the framerate of the video
   const [videoFramerate, setVideoFramerate] = useState<number | null>(null)
+
+  const videoRef = useRef<HTMLVideoElement>(null)
 
   useEffect(() => {
     setVideoFramerate(null)
@@ -190,6 +193,7 @@ export const SpliceVideoProvider: FC<SpliceVideoProviderProps> = ({ children }) 
       handleSpliceVideo,
       errorMessages,
       videoFramerate,
+      videoRef,
     }
   }, [selectedVideo, numSplicePointsCompleted, updateSelectedVideo, splicePoints, isSplicingVideo, handleSpliceVideo, deleteSplicePoint, addSplicePoint, modifySplicePoint, errorMessages])
 

--- a/src/contexts/SpliceVideoContext.tsx
+++ b/src/contexts/SpliceVideoContext.tsx
@@ -18,7 +18,8 @@ export interface SpliceVideoContextValue {
   }) => void
   errorMessages: string[]
   videoFramerate: number | null
-  videoRef?: React.RefObject<HTMLVideoElement>
+  videoRef: HTMLVideoElement | null
+  setVideoRef: (video: HTMLVideoElement | null) => void
 }
 
 const SpliceVideoContext = createContext<SpliceVideoContextValue>(undefined as any)
@@ -38,7 +39,7 @@ export const SpliceVideoProvider: FC<SpliceVideoProviderProps> = ({ children }) 
   // when selectedVideo changes, use electron to get the framerate of the video
   const [videoFramerate, setVideoFramerate] = useState<number | null>(null)
 
-  const videoRef = useRef<HTMLVideoElement>(null)
+  const [videoRef, setVideoRef] = useState<HTMLVideoElement | null>(null)
 
   useEffect(() => {
     setVideoFramerate(null)
@@ -194,6 +195,7 @@ export const SpliceVideoProvider: FC<SpliceVideoProviderProps> = ({ children }) 
       errorMessages,
       videoFramerate,
       videoRef,
+      setVideoRef,
     }
   }, [selectedVideo, numSplicePointsCompleted, updateSelectedVideo, splicePoints, isSplicingVideo, handleSpliceVideo, deleteSplicePoint, addSplicePoint, modifySplicePoint, errorMessages])
 

--- a/src/pages/SpliceVideo.tsx
+++ b/src/pages/SpliceVideo.tsx
@@ -1,6 +1,6 @@
 import useSpliceVideo from '@/hooks/useSpliceVideo'
 import { Box, Button, Typography, Stack, Grid } from '@mui/material'
-import { FC, useEffect } from 'react'
+import { FC, useEffect, useRef } from 'react'
 import { ipcRenderer } from 'electron'
 import Progress from '@/components/SpliceVideo/Progress'
 import SplicePoints from '@/components/SpliceVideo/SplicePoints'


### PR DESCRIPTION
# Changelog

- Fixed bug where switching page causes splice video to break
- Fixed frame-seeking logic
- now allowing selection of splicepoint via frames or HH:MM:SS
- more intelligent start/end behavior implemented; we maintain that startFrames <= endFrames at all times
- more intelligent HH:MM:SS behavior; minutes or seconds can reach -1 or 60 and we redistribute accordingly