### PR TITLE
Saving and Loading Splicing Video Projects

### DIFF
--- a/electron/handlers/json.ts
+++ b/electron/handlers/json.ts
@@ -1,0 +1,38 @@
+import { dialog } from 'electron'
+const fs = require('fs').promises;
+
+/**
+ * Saves a JSON file to the user's computer. Prompt the user where to save the file.
+ * @param event The event that triggered this function.
+ * @param arg.data The data to save.
+ * @returns
+ */
+export const handleSaveToJSON = async (event, arg) => {
+  if (!arg.data) {
+    event.reply('save-to-json-error');
+    return;
+  }
+
+  const result = await dialog.showSaveDialog({
+    title: 'Save to JSON',
+    defaultPath: 'data.json',
+    filters: [{ name: 'JSON', extensions: ['json'] }]
+  });
+
+  if (result.canceled) {
+    event.reply('save-to-json-canceled');
+    return;
+  }
+
+  try {
+    await fs.writeFile(result.filePath, JSON.stringify(arg.data));
+    event.reply('save-to-json-success');
+  } catch (err) {
+    console.error(err);
+    event.reply('save-to-json-error');
+  }
+}
+
+export const handleLoadFromJSON = async (event) => {
+
+}

--- a/electron/handlers/json.ts
+++ b/electron/handlers/json.ts
@@ -33,6 +33,27 @@ export const handleSaveToJSON = async (event, arg) => {
   }
 }
 
+/**
+ * Turns a JSON file into a JS object.
+ * @param event The event that triggered this function.
+ * @returns
+ */
 export const handleLoadFromJSON = async (event) => {
+  const result = await dialog.showOpenDialog({
+    title: 'Load from JSON',
+    filters: [{ name: 'JSON', extensions: ['json'] }]
+  });
 
+  if (result.canceled) {
+    event.reply('load-from-json-canceled');
+    return;
+  }
+
+  try {
+    const data = await fs.readFile(result.filePaths[0]);
+    event.reply('load-from-json-success', JSON.parse(data));
+  } catch (err) {
+    console.error(err);
+    event.reply('load-from-json-error');
+  }
 }

--- a/electron/handlers/json.ts
+++ b/electron/handlers/json.ts
@@ -5,6 +5,7 @@ const fs = require('fs').promises;
  * Saves a JSON file to the user's computer. Prompt the user where to save the file.
  * @param event The event that triggered this function.
  * @param arg.data The data to save.
+ * @param {string} [arg.filename] The filename to save the data as.
  * @returns
  */
 export const handleSaveToJSON = async (event, arg) => {
@@ -15,7 +16,7 @@ export const handleSaveToJSON = async (event, arg) => {
 
   const result = await dialog.showSaveDialog({
     title: 'Save to JSON',
-    defaultPath: 'data.json',
+    defaultPath: arg?.filename || 'data.json',
     filters: [{ name: 'JSON', extensions: ['json'] }]
   });
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -150,6 +150,7 @@ import { handleBulkExtractAudio, handleSelectExtractAudioFiles, handleSelectSpli
 import { handleListNotes, handleAddNote, handleUpdateNote, handleDeleteNote } from "../handlers/note";
 import { handleDatabaseExport } from "../handlers/export";
 import { handleDatabaseImport } from "../handlers/import";
+import { handleSaveToJSON, handleLoadFromJSON } from "../handlers/json";
 
 //
 // DIRECTORY
@@ -287,4 +288,14 @@ ipcMain.on("database-export", async (event) => {
 
 ipcMain.on("database-import", async (event) => {
   handleDatabaseImport(event);
+})
+
+// JSON
+
+ipcMain.on("save-to-json", async (event, arg) => {
+  handleSaveToJSON(event, arg);
+})
+
+ipcMain.on("load-from-json", async (event) => {
+  handleLoadFromJSON(event);
 })

--- a/src/components/SpliceVideo/AutoSplice.tsx
+++ b/src/components/SpliceVideo/AutoSplice.tsx
@@ -19,7 +19,7 @@ interface AutoSpliceModalProps extends Omit<ModalProps, 'children'> {
 }
 
 const AutoSpliceModal: FC<AutoSpliceModalProps> = ({ open, onClose, autoSpliceSettings }) => {
-  const { selectedVideo, setSplicePoints } = useSpliceVideo()
+  const { selectedVideo, updateSplicePoints } = useSpliceVideo()
 
   const [isDisabled, setIsDisabled] = useState(true)
   const [isSplicing, setIsSplicing] = useState(false)
@@ -35,7 +35,7 @@ const AutoSpliceModal: FC<AutoSpliceModalProps> = ({ open, onClose, autoSpliceSe
     })
 
     ipcRenderer.once('auto-spliced', (_, splicePoints) => {
-      setSplicePoints(splicePoints)
+      updateSplicePoints(splicePoints)
       setIsSplicing(false)
       onClose()
     })

--- a/src/components/SpliceVideo/LoadProject.tsx
+++ b/src/components/SpliceVideo/LoadProject.tsx
@@ -2,8 +2,11 @@ import { ipcRenderer } from 'electron'
 import { FC, useState } from 'react'
 import { IconButton, Snackbar, Alert } from '@mui/material'
 import { Download } from '@mui/icons-material'
+import useSpliceVideo from '@/hooks/useSpliceVideo'
 
 const LoadProject: FC = () => {
+  const { updateSelectedVideo, updateSplicePoints } = useSpliceVideo()
+
   const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
   const [showErrorSnackbar, setShowErrorSnackbar] = useState(false)
 
@@ -12,6 +15,8 @@ const LoadProject: FC = () => {
 
     ipcRenderer.once('load-from-json-success', (_, data) => {
       setShowSuccessSnackbar(true)
+      updateSelectedVideo(data.selectedVideo)
+      updateSplicePoints(data.splicePoints)
     })
 
     ipcRenderer.once('load-from-json-error', () => {

--- a/src/components/SpliceVideo/LoadProject.tsx
+++ b/src/components/SpliceVideo/LoadProject.tsx
@@ -1,0 +1,41 @@
+import { ipcRenderer } from 'electron'
+import { FC, useState } from 'react'
+import { IconButton, Snackbar, Alert } from '@mui/material'
+import { Download } from '@mui/icons-material'
+
+const LoadProject: FC = () => {
+  const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
+  const [showErrorSnackbar, setShowErrorSnackbar] = useState(false)
+
+  const handleLoad = () => {
+    ipcRenderer.send('load-from-json')
+
+    ipcRenderer.once('load-from-json-success', (_, data) => {
+      setShowSuccessSnackbar(true)
+    })
+
+    ipcRenderer.once('load-from-json-error', () => {
+      setShowErrorSnackbar(true)
+    })
+  }
+
+  return (
+    <>
+      <IconButton onClick={handleLoad}>
+        <Download />
+      </IconButton>
+      <Snackbar open={showSuccessSnackbar} autoHideDuration={6000} onClose={() => setShowSuccessSnackbar(false)}>
+        <Alert severity="success" onClose={() => setShowSuccessSnackbar(false)}>
+          Project saved successfully.
+        </Alert>
+      </Snackbar>
+      <Snackbar open={showErrorSnackbar} autoHideDuration={6000} onClose={() => setShowErrorSnackbar(false)}>
+        <Alert severity="error" onClose={() => setShowErrorSnackbar(false)}>
+          Error saving project.
+        </Alert>
+      </Snackbar>
+    </>
+  )
+}
+
+export default LoadProject

--- a/src/components/SpliceVideo/SaveProject.tsx
+++ b/src/components/SpliceVideo/SaveProject.tsx
@@ -1,0 +1,51 @@
+import { ipcRenderer } from 'electron'
+import { FC, useState } from 'react'
+import { IconButton, Snackbar, Alert } from '@mui/material'
+import { Save } from '@mui/icons-material'
+import useSpliceVideo from '@/hooks/useSpliceVideo'
+
+const SaveProject: FC = () => {
+  const { splicePoints, selectedVideo } = useSpliceVideo()
+
+  const [showSuccessSnackbar, setShowSuccessSnackbar] = useState(false)
+  const [showErrorSnackbar, setShowErrorSnackbar] = useState(false)
+
+  const handleSave = () => {
+    const data = {
+      selectedVideo,
+      splicePoints
+    }
+
+    ipcRenderer.send('save-to-json', {
+      data: data,
+    })
+
+    ipcRenderer.once('save-to-json-success', () => {
+      setShowSuccessSnackbar(true)
+    })
+
+    ipcRenderer.once('save-to-json-error', () => {
+      setShowErrorSnackbar(true)
+    })
+  }
+
+  return (
+    <>
+      <IconButton onClick={handleSave}>
+        <Save />
+      </IconButton>
+      <Snackbar open={showSuccessSnackbar} autoHideDuration={6000} onClose={() => setShowSuccessSnackbar(false)}>
+        <Alert severity="success" onClose={() => setShowSuccessSnackbar(false)}>
+          Project saved successfully.
+        </Alert>
+      </Snackbar>
+      <Snackbar open={showErrorSnackbar} autoHideDuration={6000} onClose={() => setShowErrorSnackbar(false)}>
+        <Alert severity="error" onClose={() => setShowErrorSnackbar(false)}>
+          Error saving project.
+        </Alert>
+      </Snackbar>
+    </>
+  )
+}
+
+export default SaveProject

--- a/src/components/SpliceVideo/SaveProject.tsx
+++ b/src/components/SpliceVideo/SaveProject.tsx
@@ -31,7 +31,7 @@ const SaveProject: FC = () => {
 
   return (
     <>
-      <IconButton onClick={handleSave}>
+      <IconButton onClick={handleSave} disabled={!selectedVideo}>
         <Save />
       </IconButton>
       <Snackbar open={showSuccessSnackbar} autoHideDuration={6000} onClose={() => setShowSuccessSnackbar(false)}>

--- a/src/components/SpliceVideo/SaveProject.tsx
+++ b/src/components/SpliceVideo/SaveProject.tsx
@@ -18,6 +18,7 @@ const SaveProject: FC = () => {
 
     ipcRenderer.send('save-to-json', {
       data: data,
+      filename: 'project.json'
     })
 
     ipcRenderer.once('save-to-json-success', () => {

--- a/src/components/SpliceVideo/SplicePoints.tsx
+++ b/src/components/SpliceVideo/SplicePoints.tsx
@@ -7,7 +7,7 @@ import { Modal, ModalProps } from '../Modal'
 interface DeleteModalProps extends Omit<ModalProps, 'children'> { }
 
 const DeleteModal: FC<DeleteModalProps> = ({ open, onClose }) => {
-  const { setSplicePoints } = useSpliceVideo()
+  const { updateSplicePoints } = useSpliceVideo()
 
   return (
     <Modal open={open} onClose={onClose}>
@@ -26,7 +26,7 @@ const DeleteModal: FC<DeleteModalProps> = ({ open, onClose }) => {
           </Box>
           <Box>
             <Button color='error' variant='contained' onClick={() => {
-              setSplicePoints([])
+              updateSplicePoints([])
               onClose()
             }}>
               Delete All Splice Points

--- a/src/contexts/SpliceVideoContext.tsx
+++ b/src/contexts/SpliceVideoContext.tsx
@@ -9,7 +9,7 @@ export interface SpliceVideoContextValue {
   addSplicePoint: (currentTime: number) => void
   deleteSplicePoint: (splicePoint: [number, number]) => void
   modifySplicePoint: (splicePoint: [number, number], newSplicePoint: [number, number]) => void
-  setSplicePoints: (splicePoints: [number, number][]) => void
+  updateSplicePoints: (splicePoints: [number, number][]) => void
   numSplicePointsCompleted: number
   isSplicingVideo: boolean
   handleSpliceVideo: ({
@@ -97,6 +97,7 @@ export const SpliceVideoProvider: FC<SpliceVideoProviderProps> = ({ children }) 
 
   const updateSelectedVideo = (video: string) => {
     setSelectedVideo(video)
+    setSplicePoints([])
   }
 
   const updateSplicePoints = (splicePoints: [number, number][]) => {
@@ -164,10 +165,6 @@ export const SpliceVideoProvider: FC<SpliceVideoProviderProps> = ({ children }) 
   }
 
   useEffect(() => {
-    setSplicePoints([])
-  }, [selectedVideo])
-
-  useEffect(() => {
     ipcRenderer.on('spliced-point-video', () => {
       setNumSplicePointsCompleted((prev) => prev + 1)
     })
@@ -197,9 +194,9 @@ export const SpliceVideoProvider: FC<SpliceVideoProviderProps> = ({ children }) 
       videoFramerate,
       videoRef,
       setVideoRef,
-      setSplicePoints,
+      updateSplicePoints,
     }
-  }, [selectedVideo, numSplicePointsCompleted, updateSelectedVideo, splicePoints, isSplicingVideo, handleSpliceVideo, deleteSplicePoint, addSplicePoint, modifySplicePoint, errorMessages, videoFramerate, videoRef, setVideoRef, setSplicePoints])
+  }, [selectedVideo, numSplicePointsCompleted, updateSelectedVideo, splicePoints, isSplicingVideo, handleSpliceVideo, deleteSplicePoint, addSplicePoint, modifySplicePoint, errorMessages, videoFramerate, videoRef, setVideoRef, updateSplicePoints])
 
   return (
     <SpliceVideoContext.Provider value={contextValue}>

--- a/src/pages/SpliceVideo.tsx
+++ b/src/pages/SpliceVideo.tsx
@@ -1,11 +1,14 @@
 import useSpliceVideo from '@/hooks/useSpliceVideo'
-import { Box, Button, Typography, Stack, Grid } from '@mui/material'
-import { FC, useEffect, useRef } from 'react'
+import { Box, Button, Typography, Stack, Grid, IconButton } from '@mui/material'
+import { FC, useEffect } from 'react'
 import { ipcRenderer } from 'electron'
 import Progress from '@/components/SpliceVideo/Progress'
 import SplicePoints from '@/components/SpliceVideo/SplicePoints'
 import VideoControls from '@/components/SpliceVideo/VideoControls'
 import AutoSplice from '@/components/SpliceVideo/AutoSplice'
+import { Download } from '@mui/icons-material'
+import SaveProject from '@/components/SpliceVideo/SaveProject'
+import LoadProject from '@/components/SpliceVideo/LoadProject'
 
 const SpliceVideo: FC = () => {
   const { updateSelectedVideo, selectedVideo } = useSpliceVideo()
@@ -30,11 +33,19 @@ const SpliceVideo: FC = () => {
           <Typography variant="h4">
             Splice Video
           </Typography>
-          <Box>
-            <Button onClick={handleSelectVideo} variant='contained'>
-              Select Video
-            </Button>
-          </Box>
+          <Stack direction='row' gap={1}>
+            <Box>
+              <SaveProject />
+            </Box>
+            <Box>
+              <LoadProject />
+            </Box>
+            <Box>
+              <Button onClick={handleSelectVideo} variant='contained'>
+                Select Video
+              </Button>
+            </Box>
+          </Stack>
         </Stack>
         <Grid container spacing={2}>
           <Grid item xs={12} md={6}


### PR DESCRIPTION
# Changelog

- users are able to save video splicing projects as a JSON file
- users are able to load a video splicing project from a JSON file

https://github.com/ptrandev/marine-databaser/assets/15660380/627e7367-775d-4c3b-8e15-b791f06fbb1b

